### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/contato0587/2c2c4ff1-bc11-438a-af31-bb3a23d3a6e8/aa309d2a-bb08-4fd5-9513-4e9d7031efa5/_apis/work/boardbadge/ab9d7e5a-9c5c-42a4-b039-99b6d800c711)](https://dev.azure.com/contato0587/2c2c4ff1-bc11-438a-af31-bb3a23d3a6e8/_boards/board/t/aa309d2a-bb08-4fd5-9513-4e9d7031efa5/Microsoft.RequirementCategory)
 # knowledge-matrix
 Knowledge Matrix
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/contato0587/2c2c4ff1-bc11-438a-af31-bb3a23d3a6e8/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.